### PR TITLE
Make bootstrap section optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform/

--- a/iam.tf
+++ b/iam.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "emr_autoscaling_role_policy" {
 
     principals = {
       type        = "Service"
-      identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
+      identifiers = ["elasticmapreduce.amazonaws.com", "application-autoscaling.amazonaws.com"]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -26,11 +26,7 @@ resource "aws_emr_cluster" "cluster" {
 
   autoscaling_role = "${aws_iam_role.emr_autoscaling_role.arn}"
 
-  bootstrap_action {
-    path = "${var.bootstrap_uri}"
-    name = "${var.bootstrap_name}"
-    args = "${var.bootstrap_args}"
-  }
+  bootstrap_action = "${var.bootstrap_action}"
 
   log_uri      = "${var.log_uri}"
   service_role = "${aws_iam_role.emr_service_role.arn}"

--- a/security.tf
+++ b/security.tf
@@ -35,21 +35,21 @@ resource "aws_security_group" "service_access" {
 }
 
 resource "aws_security_group_rule" "master_allow_all_egress" {
-  type            = "egress"
-  from_port       = 0
-  to_port         = 65535
-  protocol        = "all"
-  cidr_blocks     = ["0.0.0.0/0"]
+  type        = "egress"
+  from_port   = 0
+  to_port     = 65535
+  protocol    = "all"
+  cidr_blocks = ["0.0.0.0/0"]
 
   security_group_id = "${aws_security_group.emr_master.id}"
 }
 
 resource "aws_security_group_rule" "slave_allow_all_egress" {
-  type            = "egress"
-  from_port       = 0
-  to_port         = 65535
-  protocol        = "all"
-  cidr_blocks     = ["0.0.0.0/0"]
+  type        = "egress"
+  from_port   = 0
+  to_port     = 65535
+  protocol    = "all"
+  cidr_blocks = ["0.0.0.0/0"]
 
   security_group_id = "${aws_security_group.emr_slave.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -51,9 +51,13 @@ variable "additional_master_security_groups" {
   default = ""
 }
 
-variable "bootstrap_name" {}
+variable "bootstrap_name" {
+  default = ""
+}
 
-variable "bootstrap_uri" {}
+variable "bootstrap_uri" {
+  default = ""
+}
 
 variable "bootstrap_args" {
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -51,17 +51,9 @@ variable "additional_master_security_groups" {
   default = ""
 }
 
-variable "bootstrap_name" {
-  default = ""
-}
-
-variable "bootstrap_uri" {
-  default = ""
-}
-
-variable "bootstrap_args" {
-  default = []
-  type    = "list"
+variable "bootstrap_action" {
+  default = {}
+  type = "map"
 }
 
 variable "log_uri" {}

--- a/variables.tf
+++ b/variables.tf
@@ -53,7 +53,7 @@ variable "additional_master_security_groups" {
 
 variable "bootstrap_action" {
   default = []
-  type = "list"
+  type    = "list"
 }
 
 variable "log_uri" {}

--- a/variables.tf
+++ b/variables.tf
@@ -52,8 +52,8 @@ variable "additional_master_security_groups" {
 }
 
 variable "bootstrap_action" {
-  default = {}
-  type = "map"
+  default = []
+  type = "list"
 }
 
 variable "log_uri" {}


### PR DESCRIPTION
This is a breaking change since the below variables are no longer used:
* `bootstrap_name`
* `bootstrap_uri`
* `bootstrap_args`

Also applied `terraform fmt` on the files.