### PR TITLE
Revert "Make bootstrap section optional"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.terraform/

--- a/iam.tf
+++ b/iam.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "emr_autoscaling_role_policy" {
 
     principals = {
       type        = "Service"
-      identifiers = ["elasticmapreduce.amazonaws.com", "application-autoscaling.amazonaws.com"]
+      identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,11 @@ resource "aws_emr_cluster" "cluster" {
 
   autoscaling_role = "${aws_iam_role.emr_autoscaling_role.arn}"
 
-  bootstrap_action = "${var.bootstrap_action}"
+  bootstrap_action {
+    path = "${var.bootstrap_uri}"
+    name = "${var.bootstrap_name}"
+    args = "${var.bootstrap_args}"
+  }
 
   log_uri      = "${var.log_uri}"
   service_role = "${aws_iam_role.emr_service_role.arn}"

--- a/security.tf
+++ b/security.tf
@@ -35,21 +35,21 @@ resource "aws_security_group" "service_access" {
 }
 
 resource "aws_security_group_rule" "master_allow_all_egress" {
-  type        = "egress"
-  from_port   = 0
-  to_port     = 65535
-  protocol    = "all"
-  cidr_blocks = ["0.0.0.0/0"]
+  type            = "egress"
+  from_port       = 0
+  to_port         = 65535
+  protocol        = "all"
+  cidr_blocks     = ["0.0.0.0/0"]
 
   security_group_id = "${aws_security_group.emr_master.id}"
 }
 
 resource "aws_security_group_rule" "slave_allow_all_egress" {
-  type        = "egress"
-  from_port   = 0
-  to_port     = 65535
-  protocol    = "all"
-  cidr_blocks = ["0.0.0.0/0"]
+  type            = "egress"
+  from_port       = 0
+  to_port         = 65535
+  protocol        = "all"
+  cidr_blocks     = ["0.0.0.0/0"]
 
   security_group_id = "${aws_security_group.emr_slave.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,11 @@ variable "additional_master_security_groups" {
   default = ""
 }
 
-variable "bootstrap_action" {
+variable "bootstrap_name" {}
+
+variable "bootstrap_uri" {}
+
+variable "bootstrap_args" {
   default = []
   type    = "list"
 }


### PR DESCRIPTION
Reverts chrissng/terraform-aws-emr-cluster#8

The means to supply bootstrap actions is hard due to the change in the PR. As such, reverting to a version where bootstrap action is possible.